### PR TITLE
fix python-json-logger requirement to >=3.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d12ce2d9aeae5c4ec4232c88bc478443412b110c0f331a72aeadb980e9724c8b
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - docket = docket.__main__:app
@@ -31,7 +31,7 @@ requirements:
     - opentelemetry-exporter-prometheus >=0.51b0
     - prometheus_client >=0.21.1
     - py-key-value-aio >=0.3.0
-    - python-json-logger >=2.0.7
+    - python-json-logger >=3.2.1
     - redis-py >=5
     - rich >=13.9.4
     - typer >=0.15.1


### PR DESCRIPTION
## Summary

The pydocket recipe incorrectly specified `python-json-logger >=2.0.7`, but the upstream pydocket package requires `>=3.2.1`. This causes pip check failures in downstream packages.

## Changes
- Updated python-json-logger requirement from >=2.0.7 to >=3.2.1
- Bumped build number from 0 to 1

## Fixes
This resolves pip check failures seen in https://github.com/conda-forge/prefect-feedstock/pull/416