### PR TITLE
Drop fakeredis/lupa, add burner-redis (also tidy stale deps)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4b5132a5754ba54f894d46bf2cbdc12e237adada73bc76ca367017536098df7f
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - docket = docket.__main__:app
@@ -26,12 +26,10 @@ requirements:
     - hatch-vcs
   run:
     - python
-    - cachetools >=5.0.0
+    - burner-redis >=0.1.6
     - cloudpickle >=3.1.1
     - cronsim >=2.6
     - exceptiongroup >=1.2.0  # [py<311]
-    - fakeredis >=2.32.1
-    - lupa >=2.0  # [py<313]
     - taskgroup >=0.2.2  # [py<311]
     - opentelemetry-api >=1.33.0
     - opentelemetry-exporter-prometheus >=0.60b0
@@ -39,6 +37,7 @@ requirements:
     - prometheus_client >=0.21.1
     - py-key-value-aio >=0.3.0
     - python-json-logger >=2.0.7
+    - python-tzdata >=2025.2  # [win]
     - redis-py >=5
     - rich >=13.9.4
     - typer >=0.15.1


### PR DESCRIPTION
The 0.20.0 autotick PR (#38) bumped the version but missed the dependency swap from `fakeredis[lua]` to `burner-redis`. While in here, also dropped `cachetools` (not used by docket; appears to have been stale from an earlier version) and added `python-tzdata` on Windows to mirror upstream's `tzdata>=2025.2; sys_platform == 'win32'`.

Bumping build number to 1 since this is a same-version dep change.

Upstream context:
- chrisguidry/docket#394 (fakeredis → burner-redis)
- chrisguidry/docket#399 (pin >=0.1.6)

⚠️ Depends on conda-forge/burner-redis-feedstock#4 landing first (0.1.6 update; bot PR, all checks green). Holding as draft until that merges and the new build shows up in the channel.